### PR TITLE
Add descriptive docstrings across stochastic volatility modules

### DIFF
--- a/FractionalBrownian/ToolsFBM.py
+++ b/FractionalBrownian/ToolsFBM.py
@@ -19,6 +19,7 @@ from scipy.optimize import curve_fit
 
 
 def get_mean_ratio_rs(x_t: Types.ndarray, chunksize: int = 1):
+    """Estimate the average rescaled range for samples ``x_t``."""
     no_elements = len(x_t)
     index = list(range(0, no_elements, chunksize))
     no_packages = len(index)
@@ -39,6 +40,7 @@ def get_mean_ratio_rs(x_t: Types.ndarray, chunksize: int = 1):
 
 
 def get_estimator_rs(x_t: Types.ndarray, lower_chunksize: int = 0, upper_chunksize: int = 1):
+    """Fit the rescaled range estimator of the Hurst exponent."""
     rs = []
     log_no_elements = []
 
@@ -56,6 +58,7 @@ def get_estimator_rs(x_t: Types.ndarray, lower_chunksize: int = 0, upper_chunksi
 
 
 def get_estimator_pe(x_t: Types.ndarray, size_f: int):
+    """Estimate the Hurst exponent using the periodogram method."""
     no_elements = len(x_t)
     f_i = np.linspace(-0.5, 0.5, size_f)
     sr_n = np.zeros(size_f)

--- a/FractionalBrownian/fBM.py
+++ b/FractionalBrownian/fBM.py
@@ -22,22 +22,26 @@ from MC_Engines.MC_RBergomi import ToolsVariance
 
 @nb.jit("f8(f8, f8)", nopython=True, nogil=True)
 def h(x: float, hurst_parameter: float):
+    """Helper kernel used for approximating the spectral density."""
     return np.power((x - 1.0), 2.0 * hurst_parameter) - 2.0 + np.power((1.0 - x), 2.0 * hurst_parameter)
 
 
 @nb.jit("f8(f8, f8)", nopython=True, nogil=True)
 def gamma(k: float, hurst_parameter: float):
+    """Return the gamma coefficient for the spectral representation."""
     return 0.5 * np.power(k, 2.0 * hurst_parameter) * h(1.0 / k, hurst_parameter)
 
 
 @nb.jit("f8(f8, f8, f8)", nopython=True, nogil=True)
 def covariance(s: float, t: float, hurst_parameter: float):
+    """Analytical covariance of a fractional Brownian motion."""
     alpha = 2.0 * hurst_parameter
     return 0.5 * (np.power(t, alpha) + np.power(s, alpha) - np.power(np.abs(t - s), alpha))
 
 
 @nb.jit("f8[:](i8, f8)", nopython=True, nogil=True)
 def get_spectral_representation(n: int, hurst_parameter: float):
+    """Build the coefficients for the spectral representation of fBM."""
     output = np.zeros(2 * n)
     no_nodes = 2 * n
     for i in range(0, n):
@@ -49,6 +53,7 @@ def get_spectral_representation(n: int, hurst_parameter: float):
 
 @nb.jit("f8[:,:](f8[:],f8, f8[:,:], f8, i8, i8)", nopython=True, nogil=True)
 def cholesky_method_jit(t_i: ndarray, z0: float, z: ndarray,  hurst_parameter: float, no_paths: int, no_time_steps):
+    """Numba-accelerated Cholesky sampler for fractional Brownian paths."""
     paths = np.zeros(shape=(no_paths, no_time_steps))
     sigma = np.zeros(shape=(no_time_steps - 1, no_time_steps - 1))
 
@@ -76,6 +81,7 @@ def cholesky_method(t0: float,
                     hurst_parameter: float,
                     no_paths: int,
                     no_time_steps: int):
+    """Sample fractional Brownian paths using the exact Cholesky approach."""
 
     t_i = np.linspace(t0, t1, no_time_steps)
     z_i = rng_generator.normal(mu=0.0, sigma=1.0, size=(no_paths, no_time_steps),
@@ -86,6 +92,7 @@ def cholesky_method(t0: float,
 
 @nb.jit("f8[:,:](f8[:],f8, f8[:,:], f8, i8, i8)", nopython=True, nogil=True)
 def truncated_fbm_jit(t_i: ndarray, z0: float, z: ndarray,  hurst_parameter: float, no_paths: int, no_time_steps):
+    """Sample truncated fractional Brownian motion paths using Volterra kernels."""
     paths = np.zeros(shape=(no_paths, no_time_steps))
     sigma = np.zeros(shape=(no_time_steps - 1, no_time_steps - 1))
 
@@ -113,6 +120,7 @@ def truncated_fbm(t0: float,
                   hurst_parameter: float,
                   no_paths: int,
                   no_time_steps: int):
+    """Wrapper that draws truncated fBM paths using antithetic normals."""
 
     t_i = np.linspace(t0, t1, no_time_steps)
     z_i = rng_generator.normal(mu=0.0, sigma=1.0, size=(no_paths, no_time_steps),

--- a/MC_Engines/MC_Heston/HestonTools.py
+++ b/MC_Engines/MC_Heston/HestonTools.py
@@ -24,6 +24,7 @@ def v_t_conditional_mean(k: float,
                          v_t_i_1: float,
                          t_i_1: float,
                          t_i: float):
+    """Conditional mean of the variance process over ``[t_i_1, t_i]``."""
     delta_time = (t_i - t_i_1)
     return theta + (v_t_i_1 - theta) * np.exp(- k * delta_time)
 
@@ -35,6 +36,7 @@ def v_t_conditional_variance(k: float,
                              v_t_i_1: float,
                              t_i_1: float,
                              t_i: float):
+    """Conditional variance of the Heston variance process."""
     delta_time = (t_i - t_i_1)
     exp_k_t = (1.0 - np.exp(- k * delta_time)) / k
     return epsilon * epsilon * (v_t_i_1 * np.exp(- k * delta_time) * exp_k_t + 0.5 * theta * k * exp_k_t * exp_k_t)
@@ -43,6 +45,7 @@ def v_t_conditional_variance(k: float,
 @nb.jit("f8[:](f8,f8)", nopython=True, nogil=True)
 def matching_qe_moments_qg(m: float,
                            s2: float):
+    """Match the first two moments using a quadratic-Gaussian mixture."""
     parameters = np.empty(2)
 
     phi_t_i = s2 / (m * m)
@@ -57,6 +60,7 @@ def matching_qe_moments_qg(m: float,
 @nb.jit("f8[:](f8,f8)", nopython=True, nogil=True)
 def matching_qe_moments_exp(m: float,
                             s2: float):
+    """Match the first two moments using an exponential distribution."""
     parameters = np.empty(2)
 
     phi_t_i = s2 / (m * m)
@@ -70,6 +74,7 @@ def matching_qe_moments_exp(m: float,
 def inv_exp_heston(p: float,
                    beta: float,
                    u: float):
+    """Inverse transform sampler for the QE exponential branch."""
     if u < p:
         return 0.00001
     else:
@@ -83,12 +88,14 @@ def get_integral_variance(t_i_1: float,
                           v_t_i: ndarray,
                           w_i_1: float,
                           w_i: float):
+    """Compute the trapezoidal integral of the variance between time steps."""
     delta = (t_i - t_i_1)
     return delta * (w_i_1 * v_t_i_1 + w_i * v_t_i)
 
 
 @nb.jit("(f8,f8,f8[:],f8[:],f8[:],f8[:])")
 def get_delta_weight(t_i_1, t_i, v_t_i_1, v_t_i, w_i_f, delta_weight):
+    """Accumulate Malliavin delta weights for Heston QE paths."""
     alpha1 = 1.0
     alpha2 = 0.0
     no_paths = len(w_i_f)
@@ -99,6 +106,7 @@ def get_delta_weight(t_i_1, t_i, v_t_i_1, v_t_i, w_i_f, delta_weight):
 
 @nb.jit("(f8,f8,f8[:],f8[:],f8[:], f8[:])")
 def get_var_weight(t_i_1, t_i, v_t_i_1, v_t_i, w_i_f,  var_weight):
+    """Accumulate Malliavin variance weights for Heston QE paths."""
     alpha1 = 0.5
     alpha2 = 0.5
     no_paths = len(w_i_f)
@@ -109,6 +117,7 @@ def get_var_weight(t_i_1, t_i, v_t_i_1, v_t_i, w_i_f,  var_weight):
 
 # @nb.jit("(f8[:],f8[:],f8[:],f8,f8,f8[:])")
 def get_gamma_weight(delta_weight, var_weight, inv_variance, rho, t,  gamma_weight):
+    """Build Malliavin gamma weights from delta and variance components."""
     no_paths = len(delta_weight)
     rho_c = np.sqrt(1.0 - rho * rho)
     for i in range(0, no_paths):

--- a/MC_Engines/MC_Heston/Heston_Engine.py
+++ b/MC_Engines/MC_Heston/Heston_Engine.py
@@ -20,6 +20,7 @@ from Tools import AnalyticTools, Types
 
 
 def get_time_steps(t0: float, t1: float, no_time_steps: int, **kwargs):
+    """Build the simulation grid, optionally inserting extra sampling dates."""
     if len(kwargs) > 0:
         extra_points = kwargs['extra_sampling_points']
         basis_sampling_dates = np.linspace(t0, t1, no_time_steps).tolist()
@@ -39,6 +40,7 @@ def get_path_multi_step(t0: float,
                         type_random_numbers: Types.TYPE_STANDARD_NORMAL_SAMPLING,
                         rnd_generator,
                         **kwargs) -> ndarray:
+    """Generate Heston price and variance paths with Malliavin weights."""
 
     k = parameters[0]
     theta = parameters[1]

--- a/MC_Engines/MC_Heston/VarianceMC.py
+++ b/MC_Engines/MC_Heston/VarianceMC.py
@@ -31,6 +31,7 @@ def get_variance(k: float,
                  v_t_i_1: ndarray,
                  u_i: ndarray,
                  no_paths: int):
+    """Sample the Heston variance process using the Quadratic-Exponential scheme."""
 
     # no_paths = len(v_t_i_1)
     paths = np.zeros(no_paths)

--- a/MC_Engines/MC_RBergomi/ToolsVariance.py
+++ b/MC_Engines/MC_RBergomi/ToolsVariance.py
@@ -22,6 +22,7 @@ from math import gamma
 
 @nb.jit("f8(f8, f8)", nopython=True, nogil=True)
 def beta(t, m):
+    """Compute the integrated mean-reversion kernel used in rBergomi."""
     if t < 1.0e-05:
         return t
     else:
@@ -30,6 +31,7 @@ def beta(t, m):
 
 @nb.jit("f8(f8, f8, f8)", nopython=True, nogil=True)
 def get_volterra_covariance(s: float, t: float, h: float):
+    """Return the Volterra covariance kernel for fractional Gaussian noise."""
     if s < t:
         x = s / t
         alpha = 2.0 * np.power(s, h + 0.5) * np.power(t, h - 0.5) * h / (h + 0.5)
@@ -46,16 +48,19 @@ def get_volterra_covariance(s: float, t: float, h: float):
 
 @nb.jit("f8(f8, f8, f8)", nopython=True, nogil=True)
 def get_fbm_covariance(s: float, t: float, h: float):
+    """Closed-form covariance of a fractional Brownian motion."""
     return 0.5 * (np.power(np.abs(t), 2.0 * h) + np.power(np.abs(s), 2.0 * h) - np.power(np.abs(t - s), 2.0 * h))
 
 
 @nb.jit("f8[:](f8[:], f8)", nopython=True, nogil=True)
 def get_fbm_variance(t: float, h: float):
+    """Variance of a fractional Brownian motion evaluated on grid ``t``."""
     return np.power(t, 2.0 * h)
 
 
 @nb.jit("f8(f8, f8, f8, f8)", nopython=False, nogil=True)
 def get_covariance_fbm_w_t(s: float, t: float, rho: float, h: float):
+    """Covariance between Brownian motion and fractional Brownian motion."""
     h_3_2 = h + 1.5
     h_1_2 = h + 0.5
     if s < t:
@@ -66,6 +71,7 @@ def get_covariance_fbm_w_t(s: float, t: float, rho: float, h: float):
 
 @nb.jit("f8[:](f8[:], f8)", nopython=True, nogil=True)
 def get_volterra_variance(t: ndarray, h: float):
+    """Evaluate the variance of the Volterra process at grid points ``t``."""
     no_elements = len(t)
     output = np.zeros(no_elements)
     for i in range(0, no_elements):
@@ -75,12 +81,14 @@ def get_volterra_variance(t: ndarray, h: float):
 
 @nb.jit("f8(f8, f8, f8, f8)", nopython=True, nogil=True)
 def get_covariance_w_v_w_t(s: float, t: float, rho: float, h: float):
+    """Covariance between volatility and driving Brownian motions."""
     d_h = np.sqrt(2.0 * h) / (h + 0.5)
     return rho * d_h * (np.power(s, h + 0.5) - (np.power(s - np.minimum(s, t), h + 0.5)))
 
 
 @nb.jit("f8[:,:](f8[:], f8, f8)", nopython=True, nogil=True)
 def get_covariance_matrix(t_i_s: ndarray, h: float, rho: float):
+    """Construct the joint covariance matrix for the rBergomi drivers."""
     no_time_steps = len(t_i_s)
     cov = np.zeros(shape=(2 * no_time_steps, 2 * no_time_steps))
     for i in range(0, no_time_steps):
@@ -110,6 +118,7 @@ def generate_paths_turbocharging(s0: float,
                                  noise: ndarray,
                                  t_i_s: ndarray,
                                  no_paths: int):
+    """Simulate rough Bergomi paths using the turbocharged sampling scheme."""
     no_time_steps = len(t_i_s)
     sqrt_2h = np.sqrt(2.0 * h)
     inv_rho = np.sqrt(1.0 - rho * rho)
@@ -180,6 +189,7 @@ def generate_paths_rbergomi(s0: float,
                             cholk_cov: ndarray,
                             t_i_s: ndarray,
                             no_paths: int):
+    """Simulate rough Bergomi paths using a Cholesky factorisation."""
     no_time_steps = len(t_i_s)
 
     paths = np.zeros(shape=(no_paths, no_time_steps))
@@ -241,6 +251,7 @@ def generate_paths_compose_rbergomi(s0: float,
                                     cholk_cov_long: ndarray,
                                     t_i_s: ndarray,
                                     no_paths: int):
+    """Simulate a two-factor rough Bergomi model with short and long memory."""
     no_time_steps = len(t_i_s)
 
     paths = np.zeros(shape=(no_paths, no_time_steps))
@@ -328,6 +339,7 @@ def generate_paths_rexpou1f(s0: float,
                             cholk_cov: ndarray,
                             t_i_s: ndarray,
                             no_paths: int):
+    """Simulate the rExpOU one-factor model using rough Bergomi drivers."""
     no_time_steps = len(t_i_s)
 
     paths = np.zeros(shape=(no_paths, no_time_steps))
@@ -378,6 +390,7 @@ def generate_paths_variance_rbergomi(s0: float,
                                      cholk_cov: ndarray,
                                      t_i_s: ndarray,
                                      no_paths: int):
+    """Simulate rough Bergomi variance dynamics without correlation."""
     no_time_steps = len(t_i_s)
 
     paths = np.zeros(shape=(no_paths, no_time_steps))

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ worked examples illustrating end-to-end workflows.
 - Monte Carlo pricing engines, variance reduction techniques, and reusable
   instrument definitions that decouple payoff logic from model dynamics.
 - Dedicated rough Bergomi workflows that combine fractional Brownian motion
-  sampling, forward variance curve handling, and volatility-of-volatility
-  calibration helpers.
+  sampling, forward variance curve handling.
 - Tools for sampling fractional Brownian motion and building volatility
   surfaces with SVI and SABR parameterisations.
 - Utilities written with `numba` to accelerate critical numerical kernels.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ worked examples illustrating end-to-end workflows.
   known characteristic functions such as Heston and Merton.
 - Monte Carlo pricing engines, variance reduction techniques, and reusable
   instrument definitions that decouple payoff logic from model dynamics.
+- Dedicated rough Bergomi workflows that combine fractional Brownian motion
+  sampling, forward variance curve handling, and volatility-of-volatility
+  calibration helpers.
 - Tools for sampling fractional Brownian motion and building volatility
   surfaces with SVI and SABR parameterisations.
 - Utilities written with `numba` to accelerate critical numerical kernels.
@@ -70,6 +73,9 @@ constraints.
    the instruments in [`Instruments/`](Instruments/) to price custom payoffs.
 4. Build or calibrate a volatility surface with the tools under
    [`VolatilitySurface/`](VolatilitySurface/).
+5. Experiment with the rough Bergomi engines in
+   [`MC_Engines/MC_RBergomi/`](MC_Engines/MC_RBergomi/) by simulating forward
+   variance curves, Malliavin weights, and joint spot/variance paths.
 
 A minimal script that prices a European option under the Heston model using the
 COS method could look like:
@@ -137,6 +143,19 @@ Simulation back-ends for a variety of stochastic processes under stochastic
 volatility dynamics. Engines can be combined with the pricers above to perform
 scenario analysis or pricing.
 
+#### Rough Bergomi
+The rough Bergomi implementation exposes several building blocks:
+
+- Discretisation of the Volterra kernel and hybrid scheme to simulate the
+  rough variance process driven by fractional Brownian motion.
+- Utilities for constructing forward variance curves and calibrating the
+  volatility-of-volatility parameter from market quotes.
+- Monte Carlo pricers that couple spot and variance simulations, enabling the
+  valuation of variance swaps, options on realised variance, and equity
+  derivatives with rough volatility dynamics.
+- Optional Malliavin weight computation to perform pathwise sensitivity
+  analysis with respect to model parameters.
+
 ### Solvers
 A robust one-dimensional PDE solver tailored for local volatility models. The
 solver supports explicit, implicit, and theta schemes with configurable boundary
@@ -152,6 +171,11 @@ Components for constructing and calibrating volatility term structures. Current
 implementations include SVI and SABR parameterisations.
 
 ## Development
+The entire development workflow is designed to work smoothly with
+[uv](https://github.com/astral-sh/uv). The tool handles virtual environment
+management, dependency resolution, and editable installs without requiring
+separate `pip` or `virtualenv` steps.
+
 1. Install development dependencies:
    ```bash
    uv pip install -e .[dev]

--- a/Tools/AnalyticTools.py
+++ b/Tools/AnalyticTools.py
@@ -18,15 +18,18 @@ from scipy.special import ndtr
 
 @nb.jit("f8(f8, f8, f8)", nopython=True, nogil=True)
 def normal_pdf(mean=0.0, sigma=1.0, x=0.0):
+    """Evaluate the probability density of a normal variable at ``x``."""
     return np.exp(-0.5 * np.power(x - mean, 2.0) / sigma) / np.sqrt(2 * np.pi * sigma)
 
 
 @nb.jit("f8(f8, f8, f8)", nopython=True, nogil=True)
 def log_normal_pdf(mean=0.0, sigma=1.0, x=0.0):
+    """Return the log-normal density corresponding to ``mean`` and ``sigma``."""
     return normal_pdf(mean, sigma, (np.log(x) - mean) / sigma) * 1.0 / (sigma * x)
 
 
 def bs_distribution(r=0.0, q=0.0, t=0.0, sigma=0.0, s0=0.0, s=0.0):
+    """Compute the Black–Scholes cumulative distribution for a forward price."""
     f = np.exp((r - q) * t) * s0
     sigma_t = sigma * np.sqrt(t)
     d = (np.log(s / f) / sigma_t) + 0.5 * sigma_t
@@ -35,6 +38,7 @@ def bs_distribution(r=0.0, q=0.0, t=0.0, sigma=0.0, s0=0.0, s=0.0):
 
 
 def bs_density(r=0.0, q=0.0, t=0.0, sigma=0.0, s0=0.0, s=0.0):
+    """Return the Black–Scholes density of the asset price at maturity."""
     f = np.exp((r - q) * t) * s0
     sigma_t = sigma * np.sqrt(t)
     d = (np.log(s / f) / sigma_t) + 0.5 * sigma_t
@@ -43,6 +47,7 @@ def bs_density(r=0.0, q=0.0, t=0.0, sigma=0.0, s0=0.0, s=0.0):
 
 
 def bs_approximation_distribution(r=0.0, q=0.0, t=0.0, sigma=0.0, s0=0.0, s=0.0):
+    """Approximate the Black–Scholes CDF using a low-order Taylor expansion."""
     f = np.exp((r - q) * t) * s0
     x0 = np.log(f)
     sigma_t = sigma * np.sqrt(t)
@@ -57,6 +62,7 @@ def bs_approximation_distribution(r=0.0, q=0.0, t=0.0, sigma=0.0, s0=0.0, s=0.0)
 
 @nb.jit("f8(f8,f8,i4)", nopython=True, nogil=True)
 def get_bessel_moments(t, nu, n):
+    """Evaluate the first ``n`` moments of a Bessel process at time ``t``."""
     out = 0.0
     a_k = np.empty(n + 1)
     b_k = np.empty(n + 1)
@@ -82,6 +88,7 @@ def get_bessel_moments(t, nu, n):
 
 @nb.jit("f8[:](f8[:],f8[:])", nopython=True, nogil=True)
 def dot_wise(x, y):
+    """Multiply two vectors element-wise and return the resulting vector."""
     no_elements = len(x)
     out = np.empty(no_elements)
 
@@ -93,6 +100,7 @@ def dot_wise(x, y):
 
 @nb.jit("f8(f8[:],f8[:])", nopython=True, nogil=True)
 def scalar_product(x, y):
+    """Compute the scalar product of two vectors."""
     no_elements = len(x)
     total = 0.0
     for i in range(0, no_elements):
@@ -103,6 +111,7 @@ def scalar_product(x, y):
 
 @nb.jit("f8(f8[:],f8[:], f8[:])", nopython=True, nogil=True)
 def sum_product(x, y, z):
+    """Return the sum of the element-wise product of three vectors."""
     no_elements = len(x)
     total = 0.0
 
@@ -114,6 +123,7 @@ def sum_product(x, y, z):
 
 @nb.jit("f8[:](f8[:,:],f8[:])", nopython=True, nogil=True)
 def apply_lower_tridiagonal_matrix(a, b):
+    """Apply a lower triangular matrix ``a`` to the vector ``b``."""
     no_elements = len(b)
     output = np.zeros(no_elements)
     for i in range(0, no_elements):
@@ -125,6 +135,7 @@ def apply_lower_tridiagonal_matrix(a, b):
 
 @nb.jit("f8(f8,f8)", nopython=True, nogil=True)
 def dirichlet_kernel(t: float, n: float):
+    """Evaluate the Dirichlet kernel of order ``n`` at point ``t``."""
     if np.abs(t) > 0.0:
         return np.sin((n + 0.5) * t) / (np.sin(0.5 * t) * (2.0 * n + 1.0))
     else:
@@ -133,6 +144,7 @@ def dirichlet_kernel(t: float, n: float):
 
 @nb.jit("f8(f8,f8)", nopython=True, nogil=True)
 def fejer_kernel(t: float, n: float):
+    """Evaluate Fejér's kernel of order ``n`` at point ``t``."""
     if np.abs(t) > 0.0:
         return (1.0 / n) * np.power(np.sin(0.5 * n * t) / np.sin(0.5 * t), 2.0)
     else:

--- a/Tools/Bachelier.py
+++ b/Tools/Bachelier.py
@@ -13,11 +13,12 @@ phi_hat_c = -0.001882039271
 
 @nb.jit("f8(f8)", nopython=True, nogil=True)
 def gamma_inc_inv(x):
-
+    """Approximate the inverse of the complementary error function integral."""
     return ndtr(x) + Tools.AnalyticTools.normal_pdf(0.0, 1.0, x) / x
 
 
 def bachelier(f, k, t, sigma, flag):
+    """Price a Bachelier call or put option for forward ``f`` and strike ``k``."""
 
     if f == k:
         return sigma * np.sqrt(t) * 1.0 / np.sqrt(2.0 * np.pi)
@@ -27,6 +28,7 @@ def bachelier(f, k, t, sigma, flag):
 
 
 def implied_volatility(price, f, k, t, flag):
+    """Infer the Bachelier volatility that reproduces ``price`` for the option."""
 
     if f == k:
         return np.sqrt(2.0 * np.pi / t) * price

--- a/Tools/Meshes.py
+++ b/Tools/Meshes.py
@@ -16,15 +16,18 @@ from numpy import linspace
 
 
 def uniform_mesh(no_points: int, T0: float, T1: float):
+    """Return ``no_points`` evenly spaced nodes between ``T0`` and ``T1``."""
     return linspace(T0, T1, no_points).tolist()
 
 
 class Mesh(object):
+    """Container for meshes generated from a callable grid constructor."""
     def __init__(self,
                  generator: Callable[[int, float, float], List[float]],
                  T0: float,
                  T1: float,
                  no_points: int):
+        """Create a mesh using ``generator`` between ``T0`` and ``T1``."""
 
         self._generator = generator
         self._T0 = T0
@@ -34,15 +37,19 @@ class Mesh(object):
 
     @property
     def left_boundary(self):
+        """Left-most value of the mesh."""
         return self._T0
 
     @property
     def right_boundary(self):
+        """Right-most value of the mesh."""
         return self._T1
 
     @property
     def nodes(self):
+        """All generated points of the mesh."""
         return self._points
 
     def update(self, no_points: int):
+        """Regenerate the mesh using ``no_points`` nodes."""
         self._points = self._generator(no_points, self.left_boundary, self.right_boundary)

--- a/Tools/RNG.py
+++ b/Tools/RNG.py
@@ -23,6 +23,7 @@ from scipy.special import ndtri
 @nb.jit("f8[:](f8,f8,f8[:])", nopython=False)
 # @nb.jit(nopython=True)
 def norm_inv(mu, sigma, z):
+    """Transform uniform samples ``z`` into normal variates with mean ``mu``."""
     size_z = len(z)
     normal_narray = np.empty(size_z)
 
@@ -33,23 +34,27 @@ def norm_inv(mu, sigma, z):
 
 
 class RndGenerator(object):
+    """Wrapper around ``numpy`` RNG that provides convenience sampling methods."""
     def __init__(self,
                  initial_seed: int):
+        """Initialise the generator with ``initial_seed``."""
         self._seed = initial_seed
         self._rnd_generator = np.random.RandomState(initial_seed)
 
     @property
     def rnd_generator(self):
+        """Expose the underlying ``RandomState`` instance."""
         return self._rnd_generator
 
     def set_seed(self, seed):
+        """Reset the internal seed to ``seed``."""
         self._rnd_generator.seed(seed)
 
     def uniform(self,
                 a=0.0,
                 b=1.0,
                 size=None):
-
+        """Draw uniform samples on ``[a, b]`` with the requested ``size``."""
         return self._rnd_generator.uniform(a, b, size)
 
     def normal(self,
@@ -57,6 +62,7 @@ class RndGenerator(object):
                sigma=1.0,
                size=None,
                sampling_type=TYPE_STANDARD_NORMAL_SAMPLING.REGULAR_WAY):
+        """Draw normal samples supporting regular and antithetic sampling."""
 
         if sampling_type == TYPE_STANDARD_NORMAL_SAMPLING.REGULAR_WAY:
             return self._rnd_generator.normal(mu, sigma, size)
@@ -75,6 +81,7 @@ class RndGenerator(object):
     def normal_sobol(mu=0.0,
                      sigma=1.0,
                      size=None):
+        """Generate normal variates using Sobol quasi-random sequences."""
 
         if type(size) is tuple:
             m = size[1]
@@ -91,6 +98,7 @@ class RndGenerator(object):
     def uniform_sobol(a=0.0,
                       b=1.0,
                       size=None):
+        """Generate uniform Sobol variates over ``[a, b]``."""
 
         if type(size) is tuple:
             m = size[1]

--- a/Tools/Types.py
+++ b/Tools/Types.py
@@ -24,6 +24,7 @@ MIN_VALUE_LOG_MONEYNESS = 0.00001
 
 
 class HESTON_OUTPUT(Enum):
+    """Enumerate the data arrays produced by the Heston Monte Carlo engine."""
     PATHS = 0,
     INTEGRAL_VARIANCE_PATHS = 1,
     DELTA_MALLIAVIN_WEIGHTS_PATHS_TERMINAL = 2,
@@ -33,10 +34,12 @@ class HESTON_OUTPUT(Enum):
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class RBERGOMI_OUTPUT(Enum):
+    """Output identifiers used by the rough Bergomi engines."""
     PATHS = 0,
     INTEGRAL_VARIANCE_PATHS = 1,
     SPOT_VOLATILITY_PATHS = 2,
@@ -47,10 +50,12 @@ class RBERGOMI_OUTPUT(Enum):
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class MIXEDLOGNORMAL_OUTPUT(Enum):
+    """Describe the arrays produced by the mixed log-normal engine."""
     PATHS = 0,
     INTEGRAL_VARIANCE_PATHS = 1,
     SPOT_VARIANCE_PATHS = 2,
@@ -59,6 +64,7 @@ class MIXEDLOGNORMAL_OUTPUT(Enum):
 
 
 class BERGOMI2F_OUTPUT(Enum):
+    """Enumerate outputs for the two-factor Bergomi engine."""
     PATHS = 0,
     INTEGRAL_VARIANCE_PATHS = 1,
     SPOT_VARIANCE_PATHS = 2,
@@ -66,10 +72,12 @@ class BERGOMI2F_OUTPUT(Enum):
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class ANALYTIC_MODEL(Enum):
+    """List the available analytic pricing models."""
     HESTON_MODEL_ATTARI = 0,
     HESTON_MODEL_REGULAR = 1,
     HESTON_MODEL_LEWIS = 2,
@@ -79,10 +87,12 @@ class ANALYTIC_MODEL(Enum):
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class SABR_OUTPUT(Enum):
+    """Enumerate the arrays emitted by the SABR Monte Carlo engines."""
     PATHS = 0,
     INTEGRAL_VARIANCE_PATHS = 1,
     DELTA_MALLIAVIN_WEIGHTS_PATHS_TERMINAL = 2,
@@ -95,10 +105,12 @@ class SABR_OUTPUT(Enum):
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class LOCAL_VOL_OUTPUT(Enum):
+    """Identify outputs produced by local volatility simulations."""
     PATHS = 0,
     INTEGRAL_VARIANCE_PATHS = 1,
     SPOT_VARIANCE_PATHS = 2,
@@ -107,6 +119,7 @@ class LOCAL_VOL_OUTPUT(Enum):
 
 
 class CHEYETTE_OUTPUT(Enum):
+    """Outputs available from the Cheyette interest-rate engine."""
     PATHS_X = 0,
     PATHS_Y = 1,
     RATE = 2,
@@ -114,28 +127,34 @@ class CHEYETTE_OUTPUT(Enum):
 
 
 def __str__(self):
+    """Return the underlying integer value as a string."""
     return self.value
 
 
 class TYPE_STANDARD_NORMAL_SAMPLING(Enum):
+    """Specify whether to use regular or antithetic normal sampling."""
     REGULAR_WAY = 1,
     ANTITHETIC = 2
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class TypeGreeks(Enum):
+    """Greeks supported by the Monte Carlo estimators."""
     DELTA = 0
     GAMMA = 1
     DUAL_DELTA = 2
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class TypeModel(Enum):
+    """Supported stochastic volatility model identifiers."""
     ROUGH_BERGOMI = 0
     SABR = 1
     HESTON = 2
@@ -144,39 +163,48 @@ class TypeModel(Enum):
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class EULER_SCHEME_TYPE(Enum):
+    """Euler discretisation choices for Monte Carlo engines."""
     STANDARD = 1
     LOG_NORMAL = 2
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class ESTIMATOR_TYPE(Enum):
+    """Estimator variants supported by the variance routines."""
     INTEGRATED_VARIANCE_FOURIER = 1,
     INTEGRATED_VARIANCE_EMPIRICAL = 2,
     SPOT_VARIANCE_FOURIER = 3,
     UNKNOWN = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class TypeEuropeanOption(Enum):
+    """Call or put flag used by analytic and Monte Carlo pricers."""
     CALL = 1
     PUT = -1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value
 
 
 class TypeSellBuy(Enum):
+    """Direction of a trade when quoting payoffs."""
     SELL = -1
     BUY = 1
 
     def __str__(self):
+        """Return the underlying integer value as a string."""
         return self.value


### PR DESCRIPTION
## Summary
- add concise docstrings to analytical utility functions used across the library
- describe behaviour of fractional Brownian motion helpers and estimators
- document Monte Carlo engines for Heston and rough Bergomi workflows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eab3e47b508324bec66012b18d8173